### PR TITLE
Add contract upload for automatic transaction creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ A minimal web app to help real estate professionals coordinate tasks after a pur
 
 Transactions and tasks are stored in `data/transactions.json`.
 
+## Uploading Contracts
+
+Upload a signed contract (JSON or text file with `property`, `buyer`, and `seller` fields) through the interface to automatically create a new transaction. Uploaded contracts are saved under `data/contracts`.
+

--- a/public/app.js
+++ b/public/app.js
@@ -81,4 +81,20 @@ document.getElementById('transaction-form').addEventListener('submit', async (e)
   e.target.reset();
 });
 
+document.getElementById('contract-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fileInput = document.getElementById('contract-file');
+  if (!fileInput.files.length) return;
+  const file = fileInput.files[0];
+  const text = await file.text();
+  const content = btoa(text);
+  const tx = await fetchJSON('/api/contracts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: file.name, content })
+  });
+  document.getElementById('transactions').appendChild(renderTransaction(tx));
+  e.target.reset();
+});
+
 loadTransactions();

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,13 @@
         <button type="submit">Add</button>
       </form>
     </section>
+    <section class="contract-upload">
+      <h2>Upload Signed Contract</h2>
+      <form id="contract-form">
+        <input type="file" id="contract-file" accept=".json,.txt" required />
+        <button type="submit">Upload</button>
+      </form>
+    </section>
     <section>
       <h2>Transactions</h2>
       <div id="transactions"></div>


### PR DESCRIPTION
## Summary
- allow uploading signed contracts to auto-create transactions
- add client-side form and handler for contract uploads
- document contract upload feature in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af448600108329accf594f6087d933