### PR TITLE
feat: archive transactions and drag-and-drop contract upload

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,10 +22,10 @@
     </section>
     <section class="contract-upload">
       <h2>Upload Signed Contract</h2>
-      <form id="contract-form">
-        <input type="file" id="contract-file" accept=".json,.txt,.pdf,.png,.jpg,.jpeg" required />
-        <button type="submit">Upload</button>
-      </form>
+      <div id="drop-zone" class="drop-zone">
+        <p>Drag & drop file here or click to select</p>
+        <input type="file" id="contract-file" accept=".json,.txt,.pdf,.png,.jpg,.jpeg" hidden />
+      </div>
     </section>
     <section>
       <h2>Transactions</h2>

--- a/public/styles.css
+++ b/public/styles.css
@@ -46,6 +46,16 @@ form button {
   cursor: pointer;
 }
 
+.archive-btn {
+  margin-top: 0.5rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
 .transaction {
   border: 1px solid #ddd;
   border-radius: 6px;
@@ -75,6 +85,19 @@ form button {
   border: none;
   color: var(--accent);
   cursor: pointer;
+}
+
+.drop-zone {
+  border: 2px dashed #ccc;
+  padding: 1rem;
+  text-align: center;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.drop-zone.dragover {
+  border-color: var(--accent);
+  background: #eef;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- allow transactions to be marked as archived via new API endpoint
- support drag-and-drop contract uploads with visual drop zone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af6713bf488329ba7772dc0c7c6023